### PR TITLE
senha agora pode ser vista clicando no olhinho

### DIFF
--- a/src/components/2. Tela Login/TelaLogin.js
+++ b/src/components/2. Tela Login/TelaLogin.js
@@ -7,35 +7,68 @@ import {
   FormContainer,
   TituloEntrar,
   InputsLogin,
+  InputsPassword,
   BotaoEntrar,
   LinkCadastro,
   TextoLinkCadastro,
 } from './styles';
 import axios from 'axios';
 
+import clsx from 'clsx';
+import { makeStyles } from '@material-ui/core/styles';
+import IconButton from '@material-ui/core/IconButton';
+import InputLabel from '@material-ui/core/InputLabel';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import FormControl from '@material-ui/core/FormControl';
+import Visibility from '@material-ui/icons/Visibility';
+import VisibilityOff from '@material-ui/icons/VisibilityOff';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
 const baseUrl =
   'https://us-central1-missao-newton.cloudfunctions.net/fourFoodB';
 
+const useStyles = makeStyles((theme) => ({
+  root: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  margin: {
+    margin: theme.spacing(1),
+  },
+  label: {
+    marginTop: theme.spacing(20),
+  },
+  textField: {
+    width: '21rem',
+  },
+}));
+
 function TelaLogin() {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
+  const classes = useStyles();
 
   const history = useHistory();
+
   const proximaPagina = () => {
     history.push('/feed');
   };
 
-  const handleEmail = (event) => {
-    setEmail(event.target.value);
+  const [values, setValues] = React.useState({
+    email: '',
+    password: '',
+  });
+  const handleChange = (prop) => (event) => {
+    setValues({ ...values, [prop]: event.target.value });
   };
-  const handlePassword = (event) => {
-    setPassword(event.target.value);
+  const handleClickShowPassword = () => {
+    setValues({ ...values, showPassword: !values.showPassword });
+  };
+  const handleMouseDownPassword = (event) => {
+    event.preventDefault();
   };
 
   const login = async () => {
     const loginBody = {
-      email: email,
-      password: password,
+      email: values.email,
+      password: values.password,
     };
     try {
       const response = await axios.post(`${baseUrl}/login`,
@@ -43,7 +76,6 @@ function TelaLogin() {
       );
       window.localStorage.setItem('token', response.data.token);
       window.localStorage.setItem('user', JSON.stringify(response.data.user));
-      alert('Seja bem vindo ao FourFood');
       proximaPagina();
     } catch (error) {
       console.log(error);
@@ -52,29 +84,42 @@ function TelaLogin() {
   };
 
   return (
-    <FormContainer>
+    <FormContainer className={classes.root}>
       <LogoContainer src={logoinvert} alt="logotipo ifuture" />
       <TituloEntrar>Entrar</TituloEntrar>
       <InputsLogin
         required
-        id="outlined-required"
+        id="email"
         label="E-mail"
         variant="outlined"
-        value={email}
-        onChange={handleEmail}
+        value={values.email}
+        onChange={handleChange('email')}
         placeholder="email@email.com"
       />
-      <InputsLogin
-        className="style-input"
-        required
-        type="password"
-        id="outlined-required"
-        label="Senha"
-        variant="outlined"
-        value={password}
-        onChange={handlePassword}
-        placeholder="Mínimo 6 caracteres"
-      />
+        
+        <FormControl className={clsx(classes.margin, classes.textField)} variant="outlined">
+        <InputLabel htmlFor="password">Senha</InputLabel>
+        <OutlinedInput
+          id="password"
+          type={values.showPassword ? 'text' : 'password'}
+          value={values.password}
+          onChange={handleChange('password')}
+          endAdornment={
+            <InputAdornment position="end">
+              <IconButton
+                aria-label="toggle password visibility"
+                onClick={handleClickShowPassword}
+                onMouseDown={handleMouseDownPassword}
+                edge="end"
+              >
+                {values.showPassword ? <Visibility /> : <VisibilityOff />}
+              </IconButton>
+            </InputAdornment>
+          }
+          labelWidth={70}
+        />
+      </FormControl>
+      
       <BotaoEntrar variant="contained" color="primary" onClick={login}>
         Entrar
       </BotaoEntrar>

--- a/src/components/2. Tela Login/styles.js
+++ b/src/components/2. Tela Login/styles.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import TextField from '@material-ui/core/TextField';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
 import { Button } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 
@@ -23,12 +24,6 @@ export const TituloEntrar = styled.h4`
 export const InputsLogin = styled(TextField)`
   width: 21rem;
   height: 4rem;
-  margin: 0.5rem 1rem 0.5rem 1rem;
-`;
-
-export const InputsPassword = styled(TextField)`
-  width: 21rem;
-  height: 5rem;
   margin: 0.5rem 1rem 0.5rem 1rem;
 `;
 

--- a/src/components/4. Tela Cadastro Endereço/TelaCadastroEnd.js
+++ b/src/components/4. Tela Cadastro Endereço/TelaCadastroEnd.js
@@ -3,7 +3,15 @@ import axios from 'axios';
 import {useHistory} from 'react-router-dom';
 import './styles.js';
 import logoinvert from '../../assets/imagens/logoinvert.png';
-import {LogoContainer, Container, FormContainerCadastroEndereco, TituloCadastroEnd, InputsCadastroEndereco, BotaoCadastroEndereco, LinkCadastro,
+import { 
+  LogoContainer, 
+  Container, 
+  FormContainerCadastroEndereco, 
+  TituloCadastroEnd, 
+  InputsCadastroEndereco, 
+  BotaoCadastroEndereco, 
+  LinkCadastro,
+} from './styles';
 import AppHeader from '../AppHeader';
 
 


### PR DESCRIPTION
1. Visualizar senha clicando no olhinho.
2. Retirado o alert depois do Login

Precisei editar os onChange e a forma como é captado email e senha para adequar ao Material UI. Para isto
só desestruturei as funções.

### Link Surge 
http://fluffy-badge.surge.sh/

### Imagens
![screencapture-localhost-3000-login-2020-08-12-11_44_01](https://user-images.githubusercontent.com/65511670/90029994-e646f500-dc91-11ea-8229-1ae28ee2fc2e.png)
![screencapture-localhost-3000-login-2020-08-12-11_43_55](https://user-images.githubusercontent.com/65511670/90029998-e941e580-dc91-11ea-9be6-edc56efadcbb.png)

